### PR TITLE
Add feature to use http scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ There are a lot of various features that enable a wide variety of use cases, ref
 + `default` - only `fail-on-err`
 + `fail-on-err` - `panic` on any error
 + `no-verify-ssl` - disable SSL verification for endpoints, useful for custom regions
++ `http` - enable http scheme (disabled by default)
 
 ### Path or subdomain style URLs and headers
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -87,6 +87,7 @@ default = ["fail-on-err"]
 no-verify-ssl = []
 fail-on-err = []
 tracing = ["dep:tracing"]
+http = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }

--- a/s3/README.md
+++ b/s3/README.md
@@ -49,6 +49,7 @@ There are a lot of various features that enable a wide variety of use cases, ref
 + `default` - only `fail-on-err`
 + `fail-on-err` - `panic` on any error
 + `no-verify-ssl` - disable SSL verification for endpoints, useful for custom regions
++ `http` - enable http scheme (disabled by default)
 
 ### Path or subdomain style URLs and headers
 

--- a/s3/src/bucket/client.rs
+++ b/s3/src/bucket/client.rs
@@ -26,7 +26,11 @@ pub fn create_client(
         https_connector.with_webpki_roots()
     };
 
-    let https_connector = https_connector.https_only().enable_http2().build();
+    let https_connector = if cfg!(feature = "http") {
+        https_connector.https_or_http().enable_http2().build()
+    } else {
+        https_connector.https_only().enable_http2().build()
+    };
 
     let mut timeout_connector = TimeoutConnector::new(https_connector);
     timeout_connector.set_connect_timeout(request_timeout);


### PR DESCRIPTION
Hello, added this small QoL feature to enable http. Useful in dev environment when not running https (like local minio).

I run into issue `"unsupported scheme http"` when running minio example from this repo and I was having same issue when using this crate in my project. This solved it to me. It may be useful for other people too.